### PR TITLE
Resolving UTF-8 and Reference erros with otx2crits

### DIFF
--- a/otx2crits.py
+++ b/otx2crits.py
@@ -71,7 +71,7 @@ class OTX2CRITs(object):
                 print('Pulse was already in CRITs')
                 continue
 
-            print('Adding pulse {} to CRITs.'.format(pulse['name']).encode("utf-8"))
+            print('Adding pulse {} to CRITs.'.format(pulse['name'].encode("utf-8")))
             # Get the actual indicator and event data from the pulse
             indicator_data = pulse['indicators']
             event_title = pulse['name']

--- a/otx2crits.py
+++ b/otx2crits.py
@@ -78,9 +78,11 @@ class OTX2CRITs(object):
             created = pulse['created']
             reference =''
             if not reference:
-                reference = pulse['references'][0]
-            else:
+
                 reference = 'No reference documented'
+            else:
+                reference = pulse['references'][0]
+
             description = pulse['description']
             bucket_list = pulse['tags']
 

--- a/otx2crits.py
+++ b/otx2crits.py
@@ -71,7 +71,7 @@ class OTX2CRITs(object):
                 print('Pulse was already in CRITs')
                 continue
 
-            print('Adding pulse {} to CRITs.'.format(pulse['name']))
+            print('Adding pulse {} to CRITs.'.format(pulse['name']).encode("utf-8"))
             # Get the actual indicator and event data from the pulse
             indicator_data = pulse['indicators']
             event_title = pulse['name']

--- a/otx2crits.py
+++ b/otx2crits.py
@@ -87,7 +87,7 @@ class OTX2CRITs(object):
             bucket_list = pulse['tags']
 
             # Create the CRITs event first
-            print('Adding Event to CRITs with title {}'.format(event_title).encode("utf-8"))
+            print('Adding Event to CRITs with title {}'.format(event_title.encode("utf-8")))
             params = {
                 'bucket_list' : ','.join(bucket_list),
                 'description' : description,

--- a/otx2crits.py
+++ b/otx2crits.py
@@ -117,7 +117,7 @@ class OTX2CRITs(object):
                     relationship_map.append( indicator_id )
 
             # Add a ticket to the Event to track the pulse_id
-            print('Adding ticket to Event {}'.format(event_title))
+            print('Adding ticket to Event {}'.format(event_title.encode("utf-8")))
             params = {
                 'api_key' : self.crits_api_key,
                 'username' : self.crits_username,

--- a/otx2crits.py
+++ b/otx2crits.py
@@ -76,7 +76,11 @@ class OTX2CRITs(object):
             indicator_data = pulse['indicators']
             event_title = pulse['name']
             created = pulse['created']
-            reference = pulse['references'][0]
+            reference =''
+            if not reference:
+                reference = pulse['references'][0]
+            else:
+                reference = 'No reference documented'
             description = pulse['description']
             bucket_list = pulse['tags']
 

--- a/otx2crits.py
+++ b/otx2crits.py
@@ -66,7 +66,7 @@ class OTX2CRITs(object):
             relationship_map = []
 
             print('Found pulse with id {} and title {}'.format(pulse['id'],
-                                                               pulse['name']))
+                                                               pulse['name'].encode("utf-8")))
             if self.is_pulse_in_crits(pulse['id']):
                 print('Pulse was already in CRITs')
                 continue

--- a/otx2crits.py
+++ b/otx2crits.py
@@ -87,7 +87,7 @@ class OTX2CRITs(object):
             bucket_list = pulse['tags']
 
             # Create the CRITs event first
-            print('Adding Event to CRITs with title {}'.format(event_title))
+            print('Adding Event to CRITs with title {}'.format(event_title).encode("utf-8"))
             params = {
                 'bucket_list' : ','.join(bucket_list),
                 'description' : description,


### PR DESCRIPTION
Two changes : 

1. References can be empty int otx, a conditional check helps check for that, so that the code doesn't throw an error. 

2. utf-8 encoding helps for those cases such as '\u2013' 
I've added it to those places where I kept getting hit with the error. 

Hope this helps. 